### PR TITLE
Fix concurrency error by reading stock from db all the time

### DIFF
--- a/packages/core/src/service/services/stock-movement.service.ts
+++ b/packages/core/src/service/services/stock-movement.service.ts
@@ -83,7 +83,10 @@ export class StockMovementService {
         const allocations: Allocation[] = [];
         const globalTrackInventory = (await this.globalSettingsService.getSettings(ctx)).trackInventory;
         for (const line of order.lines) {
-            const { productVariant } = line;
+            const productVariant = await this.connection
+            .getRepository(ctx, ProductVariant)
+            .andWhere(`productvariant.id = ${line.productVariant.id}`)
+            .getOne();
             const allocation = new Allocation({
                 productVariant,
                 quantity: line.quantity,
@@ -125,7 +128,10 @@ export class StockMovementService {
             value.items.push(orderItem);
         }
         for (const lineRow of orderLinesMap.values()) {
-            const { productVariant } = lineRow.line;
+            const productVariant = await this.connection
+            .getRepository(ctx, ProductVariant)
+            .andWhere(`productvariant.id = ${lineRow.line.productVariant.id}`)
+            .getOne();
             const sale = new Sale({
                 productVariant,
                 quantity: lineRow.items.length * -1,


### PR DESCRIPTION
should not use stock in memory to calculate stock, if multiple users are checking out at the same time, race condition appears, stock from the last customer will be written to db, which may not be the most up to date